### PR TITLE
Data files no longer be in /Racket.

### DIFF
--- a/xml-type-provider-use.rkt
+++ b/xml-type-provider-use.rkt
@@ -6,13 +6,9 @@
 ;;
 ;; Note, both the macro and the base file must be required.
 ;; Also, the there must be a newline between the #lang xyz and the
-;; (macro:gen-type-provider "./test-xml.txt")
+;; (macro:gen-type-provider "test-xml.txt")
 ;; Furthermore, the argument to this macro must be a string literal, not
 ;; an expression that evaluates to a string literal.
-;;
-;; The ugliest problem right now is that the data needs to be present in
-;; the /Racket folder or an absolute path to it is required.
-;; Hopefully, these limitations will be removed in a future version.
 
 ;; Tells Dr. Racket what XML to use for autocomplete.
 ;; Also satisfies background compilation. To try the autocomplete, type
@@ -21,7 +17,7 @@
 ;; options. After it fills in your selection, type a "-" again
 ;; without the quotes and repeat the process to see what attributes
 ;; that element has.
-(macro:gen-type-provider "./test-xml.txt")
+(macro:gen-type-provider "test-xml.txt")
 
 ;; Used to define the data you would like to access at runtime.
 ;; This is allowed to vary from the data used for the macro, but
@@ -29,7 +25,7 @@
 ;; of an illegal deviation is an XML element containing an attribute
 ;; that is not present in any instance of that element in the macro
 ;; data.
-(define subject (populate-at-runtime "./test-xml.txt"))
+(define subject (populate-at-runtime "test-xml.txt"))
 
 ;; Handy little function similar to (first (filter predicate a-list))
 ;; Useful for the Type Provider because the macro has no knowledge


### PR DESCRIPTION
Previously, data files to be used for the TypeProvider had
to exist in the /Racket folder as well as with the TypeProvider
itself.

Now, a relative path will be resolved to the folder within which
the file currently being edited is found. Absolute paths are still
supported as well.

[issues/#1]
